### PR TITLE
NAVQP-77: separate wpa configuration into a package

### DIFF
--- a/recipes-core/images/navq-install.bb
+++ b/recipes-core/images/navq-install.bb
@@ -23,6 +23,7 @@ PACKAGE_INSTALL = " \
 		e2fsprogs-mke2fs \
 		util-linux \
 		navq-files \
+		navq-files-wpa \
 		usb-gadgets-uuc1 \
 		u-boot-fw-utils \
 		u-boot-default-env \

--- a/recipes-core/images/navq-rootfs.bb
+++ b/recipes-core/images/navq-rootfs.bb
@@ -15,6 +15,7 @@ IMAGE_FEATURES += "			\
 
 IMAGE_INSTALL:append = "		\
     navq-files				\
+    navq-files-wpa			\
     usb-gadgets-mtp1			\
     openssh				\
     opkg				\

--- a/recipes-core/navq-files/navq-files.bb
+++ b/recipes-core/navq-files/navq-files.bb
@@ -23,7 +23,6 @@ do_install() {
 	install -d ${D}${systemd_system_unitdir}
 	install -d ${D}${sbindir}
 	install -d ${D}${systemd_system_unitdir}/multi-user.target.wants/
-	install -d ${D}${systemd_system_unitdir}/local-fs.target.wants/
 
 	# WiFi configuration
 	install -m 0644 ${WORKDIR}/wireless.network ${D}${sysconfdir}/systemd/network
@@ -49,5 +48,12 @@ do_install() {
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGES:prepend = "${PN}-wpa "
 
-FILES:${PN} += "/data /etc /lib /usr"
+FILES:${PN}-wpa = " \
+	/data \
+	${sysconfdir}/systemd/network \
+	${sysconfdir}/wpa_supplicant \
+	${systemd_system_unitdir} \
+"
+FILES:${PN} += "${sysconfdir} /lib /usr"

--- a/recipes-fsl/images/imx-image-desktop.bbappend
+++ b/recipes-fsl/images/imx-image-desktop.bbappend
@@ -15,3 +15,8 @@ do_enable_gdm_autologin () {
     sed -i "s/#  AutomaticLoginEnable = true/AutomaticLoginEnable = true/" ${IMAGE_ROOTFS}/etc/gdm3/custom.conf
     sed -i "s/#  AutomaticLogin = user1/AutomaticLogin = user/" ${IMAGE_ROOTFS}/etc/gdm3/custom.conf
 }
+
+IMAGE_INSTALL += " \
+		navq-files \
+		navq-files-wpa \
+"

--- a/recipes-fsl/images/imx-image-full.bbappend
+++ b/recipes-fsl/images/imx-image-full.bbappend
@@ -11,7 +11,8 @@ IMAGE_INSTALL:append += " \
                          tensorflow-lite-vx-delegate \
                          packagegroup-imx-ml-desktop \
                          umtp-responder \
-			 navq-files \
+                         navq-files \
+                         navq-files-wpa \
                         "
 
 APTGET_EXTRA_PACKAGES += " \


### PR DESCRIPTION
WPA configuration for an interface conflicts with NetworkManager. Separation of the WPA configuration into a separate package allows skipping the package in images where it causes problems.