### PR TITLE
NAVQP-76: disable USB type-c driver during manufacturing

### DIFF
--- a/recipes-core/images/navq-install.bb
+++ b/recipes-core/images/navq-install.bb
@@ -71,7 +71,7 @@ FB: download -f imx8mp-navq.dtb
 FB: ucmd setenv fastboot_buffer \$initrd_addr
 FB: download -f ${IMAGE_BASENAME}.uImage
 FB: ucmd run mmcargs
-FB: ucmd setenv bootargs $bootargs quiet=quiet mfgboot
+FB: ucmd setenv bootargs $bootargs quiet=quiet mfgboot initcall_blacklist=tcpci_i2c_driver_init
 FB: acmd booti \$loadaddr \$initrd_addr \$fdt_addr
 
 # upload and install boot and rootfs images

--- a/wic/navq-fixed.uuu.in
+++ b/wic/navq-fixed.uuu.in
@@ -9,7 +9,7 @@ FB: download -f navq-mfgtool.dtb
 FB: ucmd setenv fastboot_buffer $initrd_addr
 FB: download -f navq-mfgtool.initrd
 FB: ucmd run mmcargs
-FB: ucmd setenv bootargs $bootargs quiet=quiet mfgboot
+FB: ucmd setenv bootargs $bootargs quiet=quiet mfgboot initcall_blacklist=tcpci_i2c_driver_init
 FB: acmd booti $loadaddr $initrd_addr $fdt_addr
 
 # create GPT partitions


### PR DESCRIPTION
Type-C driver provokes USB port reset which in the case of the board being powered via USB causes power cycle.

Disabling of the driver helps avoiding the reset.