### PR TITLE
NAVQP-86: lsusb is missed in imx-image-desktop-ros

### DIFF
--- a/recipes-fsl/images/imx-image-desktop-ros.bb
+++ b/recipes-fsl/images/imx-image-desktop-ros.bb
@@ -127,6 +127,7 @@ APTGET_EXTRA_PACKAGES += "\
 	gstreamer1.0-nice \
 	gstreamer1.0-opencv \
 	iw   \
+	usbutils \
 	${@bb.utils.contains('PACKAGE_CLASSES', 'package_rpm', 'rpm', '', d)} \
 "
 


### PR DESCRIPTION
add usbutils to recipes-fsl/images/imx-image-desktop-ros.bb