### PR TITLE
NAVQP-75: Typos in the usb-gadget-mtp@.service file

### DIFF
--- a/recipes-navq/usb-gadgets/files/usb-gadget-mtp@.service
+++ b/recipes-navq/usb-gadgets/files/usb-gadget-mtp@.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=USB Ethernet gadget %I
+Description=USB MTP gadget %I
 After=systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/usb-gadget-eth.sh %I
+ExecStart=/usr/sbin/usb-gadget-mtp.sh %I
 
 [Install]
 WantedBy=usb-gadget.target


### PR DESCRIPTION
Replace usb-gadget-eth.sh with usb-gadget-mtp.sh in usb-gadget-mtp@.service