### PR TITLE
NAVQP-75: add umtp responder to imx image desktop images

### DIFF
--- a/recipes-fsl/images/imx-image-desktop-ros.bb
+++ b/recipes-fsl/images/imx-image-desktop-ros.bb
@@ -12,6 +12,7 @@ IMAGE_INSTALL:append = "opencv \
 			tensorflow-lite-vx-delegate \
 			packagegroup-imx-ml-desktop \
 			usb-gadgets-eth2 \
+			umtp-responder \
 			"
 
 IMAGE_INSTALL:remove = "chromium-ozone-wayland"

--- a/recipes-fsl/images/imx-image-desktop.bbappend
+++ b/recipes-fsl/images/imx-image-desktop.bbappend
@@ -19,4 +19,5 @@ do_enable_gdm_autologin () {
 IMAGE_INSTALL += " \
 		navq-files \
 		navq-files-wpa \
+		umtp-responder \
 "


### PR DESCRIPTION
Add umtp-responder to recipes-fsl/images/imx-image-desktop-ros.bb and recipes-fsl/images/imx-image-desktop.bbappend,
umtp-responder is required by usb-gadget-mtp@.service