### PR TITLE
NAVQP-29: Reorganize navq-files

### DIFF
--- a/recipes-core/images/navq-install.bb
+++ b/recipes-core/images/navq-install.bb
@@ -22,8 +22,6 @@ PACKAGE_INSTALL = " \
 		dosfstools \
 		e2fsprogs-mke2fs \
 		util-linux \
-		navq-files \
-		navq-files-wpa \
 		usb-gadgets-uuc1 \
 		usb-gadgets-uuc2 \
 		u-boot-fw-utils \

--- a/recipes-core/images/navq-rootfs.bb
+++ b/recipes-core/images/navq-rootfs.bb
@@ -15,6 +15,7 @@ IMAGE_FEATURES += "			\
 
 IMAGE_INSTALL:append = "		\
     navq-swu-scripts			\
+    navq-wpa-supplicant		\
     usb-gadgets-mtp1			\
     openssh				\
     opkg				\

--- a/recipes-core/images/navq-rootfs.bb
+++ b/recipes-core/images/navq-rootfs.bb
@@ -14,8 +14,7 @@ IMAGE_FEATURES += "			\
 "
 
 IMAGE_INSTALL:append = "		\
-    navq-files				\
-    navq-files-wpa			\
+    navq-swu-scripts			\
     usb-gadgets-mtp1			\
     openssh				\
     opkg				\

--- a/recipes-fsl/images/imx-image-desktop-ros.bb
+++ b/recipes-fsl/images/imx-image-desktop-ros.bb
@@ -13,6 +13,7 @@ IMAGE_INSTALL:append = "opencv \
 			packagegroup-imx-ml-desktop \
 			usb-gadgets-eth2 \
 			umtp-responder \
+			navq-kmod-mlan \
 			"
 
 IMAGE_INSTALL += "install-interface-config install-dns-config"
@@ -214,9 +215,6 @@ fakeroot do_install_home_files() {
 
 	set +x
 }
-
-IMAGE_INSTALL += "navq-files"
-
 
 fakeroot do_aptget_user_update() {
 	wget -q -P ${APTGET_CHROOT_DIR}/ https://github.com/rudislabs/NavQPlus-Resources/raw/lf-5.15.32_2.0.0/python/tflite_runtime-2.12.0-cp310-cp310-linux_aarch64.whl

--- a/recipes-fsl/images/imx-image-desktop.bbappend
+++ b/recipes-fsl/images/imx-image-desktop.bbappend
@@ -17,8 +17,7 @@ do_enable_gdm_autologin () {
 }
 
 IMAGE_INSTALL += " \
-		navq-files \
-		navq-files-wpa \
+		navq-wpa-supplicant \
 		umtp-responder \
 		usb-gadgets \
 "

--- a/recipes-fsl/images/imx-image-full.bbappend
+++ b/recipes-fsl/images/imx-image-full.bbappend
@@ -11,8 +11,7 @@ IMAGE_INSTALL:append += " \
                          tensorflow-lite-vx-delegate \
                          packagegroup-imx-ml-desktop \
                          umtp-responder \
-                         navq-files \
-                         navq-files-wpa \
+                         navq-wpa-supplicant \
                         "
 
 APTGET_EXTRA_PACKAGES += " \

--- a/recipes-navq/navq-kmod-mlan/files/nxp_depmod.conf
+++ b/recipes-navq/navq-kmod-mlan/files/nxp_depmod.conf
@@ -1,0 +1,4 @@
+# Force modprobe to search kernel/net/wireless (where the NXP
+# version of cfg80211.ko is placed) before looking in updates/net/wireless/
+# (where the Cypress version is)
+override cfg80211 * kernel/net/wireless

--- a/recipes-navq/navq-kmod-mlan/files/nxp_modules.conf
+++ b/recipes-navq/navq-kmod-mlan/files/nxp_modules.conf
@@ -1,0 +1,8 @@
+# Prevent the Cypress version of cfg80211.ko from being loaded.
+blacklist cfg80211
+
+# Alias for the NXP module(1ZM)
+alias sdio:c*v02DFd9149 moal
+
+# Specify arguments to pass when loading the moal module
+options moal mod_para=nxp/wifi_mod_para.conf

--- a/recipes-navq/navq-kmod-mlan/navq-kmod-mlan.bb
+++ b/recipes-navq/navq-kmod-mlan/navq-kmod-mlan.bb
@@ -1,0 +1,23 @@
+# Copyrigh (C) 2022 VoxelBotics
+# Wifi driver configs
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+	file://nxp_depmod.conf \
+	file://nxp_modules.conf \
+"
+
+do_install() {
+	install -d ${D}
+	install -d ${D}${sysconfdir}/depmod.d
+	install -d ${D}${sysconfdir}/modprobe.d
+
+	install -m 0644 ${WORKDIR}/nxp_depmod.conf ${D}${sysconfdir}/depmod.d
+	install -m 0644 ${WORKDIR}/nxp_modules.conf ${D}${sysconfdir}/modprobe.d
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+FILES:${PN} = "${sysconfdir}"

--- a/recipes-navq/navq-swu-scripts/files/install_update.sh
+++ b/recipes-navq/navq-swu-scripts/files/install_update.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z '$1' ]; then
+    echo install_update.sh requires .swu file name as the only parameter
+fi
+
+if [ "`fw_printenv -n mmcpart 2>/dev/null`" = 2 ]; then
+    mode=copy1
+    echo Updating Image \#1
+else
+    mode=copy2
+    echo Updating Image \#2
+fi
+
+if swupdate -L -i $1 -e "stable,$mode" -v; then
+    echo Update succeeded, rebooting...
+    reboot
+else
+    echo Update failed
+fi

--- a/recipes-navq/navq-swu-scripts/files/rollback_update.sh
+++ b/recipes-navq/navq-swu-scripts/files/rollback_update.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ "`fw_printenv -n mmcpart 2>/dev/null`" = 2 ]; then
+    fw_setenv mmcpart 1
+    echo Rollback to Image \#1
+else
+    fw_setenv mmcpart 2
+    echo Rollback to Image \#2
+fi
+
+reboot

--- a/recipes-navq/navq-swu-scripts/navq-swu-scripts.bb
+++ b/recipes-navq/navq-swu-scripts/navq-swu-scripts.bb
@@ -1,0 +1,30 @@
+# Copyrigh (C) 2022 VoxelBotics
+# SWUpdate scripts
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+	file://install_update.sh \
+	file://rollback_update.sh \
+"
+
+do_install() {
+	install -d ${D}
+	install -d ${D}${sysconfdir}/
+	install -d ${D}${sbindir}
+
+	# access to U-Boot env
+	echo "/dev/mmcblk2    0x400000        0x4000" > ${D}${sysconfdir}/fw_env.config
+	ln -sf u-boot-imx-initial-env ${D}${sysconfdir}/u-boot-initial-env
+
+	echo "${SWU_BOARD} ${SWU_HWCOMPAT}" > ${D}${sysconfdir}/hwrevision
+	echo -e "bootloader\t\t${SWU_UBOOT_VERSION}" > ${D}${sysconfdir}/sw-versions
+
+	install -m 0755 ${WORKDIR}/install_update.sh ${D}${sbindir}
+	install -m 0755 ${WORKDIR}/rollback_update.sh ${D}${sbindir}
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+FILES:${PN} = "${sysconfdir} ${sbindir}"

--- a/recipes-navq/navq-wpa-supplicant/files/wireless.network
+++ b/recipes-navq/navq-wpa-supplicant/files/wireless.network
@@ -1,0 +1,10 @@
+[Match]
+Name=mlan0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac
+SendHostname=True
+Hostname=Navq+

--- a/recipes-navq/navq-wpa-supplicant/navq-wpa-supplicant.bb
+++ b/recipes-navq/navq-wpa-supplicant/navq-wpa-supplicant.bb
@@ -1,0 +1,40 @@
+# Copyrigh (C) 2022 VoxelBotics
+# wpa_supplicant configs
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+	file://wireless.network \
+"
+
+SERVICE_LINKS_DIR = "${sysconfdir}/systemd/system/multi-user.target.wants"
+
+do_install() {
+	install -d ${D}
+	install -d ${D}/data
+	install -d ${D}${sysconfdir}/wpa_supplicant
+	install -d ${D}${sysconfdir}/systemd/network
+	install -d ${D}${SERVICE_LINKS_DIR}
+
+	# WiFi configuration
+	install -m 0644 ${WORKDIR}/wireless.network ${D}${sysconfdir}/systemd/network
+	ln -sf /data/etc/wpa_supplicant/wpa_supplicant-mlan0.conf ${D}${sysconfdir}/wpa_supplicant/wpa_supplicant-mlan0.conf
+	ln -s /lib/systemd/system/wpa_supplicant@.service ${D}${SERVICE_LINKS_DIR}/wpa_supplicant@mlan0.service
+
+	# populate /data/etc for SD card boot which doesn't have a separate data partition
+	install -d ${D}/data/etc/wpa_supplicant/
+	echo -e "ctrl_interface=/var/run/wpa_supplicant\nctrl_interface_group=0\nupdate_config=1\n\n" > ${D}/data/etc/wpa_supplicant/wpa_supplicant-mlan0.conf
+	echo -e "network={\nssid=\"SSID\"\nscan_ssid=1\npsk=\"password\"\n}\n" >> ${D}/data/etc/wpa_supplicant/wpa_supplicant-mlan0.conf
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+RDEPENDS:${PN} = "navq-kmod-mlan"
+
+FILES:${PN} = " \
+	/data \
+	${sysconfdir}/systemd/network \
+	${sysconfdir}/wpa_supplicant \
+	${SERVICE_LINKS_DIR}/wpa_supplicant@mlan0.service \
+"

--- a/recipes-navq/navq-wpa-supplicant/navq-wpa-supplicant.bb
+++ b/recipes-navq/navq-wpa-supplicant/navq-wpa-supplicant.bb
@@ -30,7 +30,7 @@ do_install() {
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-RDEPENDS:${PN} = "navq-kmod-mlan"
+RDEPENDS:${PN} = "navq-kmod-mlan wpa-supplicant"
 
 FILES:${PN} = " \
 	/data \

--- a/scripts/build5-15-32.sh
+++ b/scripts/build5-15-32.sh
@@ -128,7 +128,6 @@ DISTRO=${DISTRO} MACHINE=imx8mpnavq EULA=yes BUILD_DIR=builddir source ./${SETUP
 
 sed -i 's/^DL_DIR.*$/DL_DIR\ \?=\ \"\/home\/cache\/CACHE\/5.15.32\/downloads\/\"/' conf/local.conf || exit $?
 echo "SSTATE_DIR = \"/home/cache/CACHE/5.15.32/sstate-cache\"" >> conf/local.conf || exit $?
-echo "IMAGE_INSTALL:append = \" navq-files \"" >> conf/local.conf || exit $?
 echo "BBMASK += \"$BBMASK\"" >> conf/local.conf || exit $?
 sed -i -e "s/BB_DEFAULT_UMASK =/BB_DEFAULT_UMASK ?=/" ../sources/poky/meta/conf/bitbake.conf
 sed -i -e "s/PACKAGE_CLASSES = \"package_rpm\"/PACKAGE_CLASSES ?= \"package_rpm\"/" conf/local.conf


### PR DESCRIPTION
1. Move install_update.sh and rollback_update.sh sctipts to navq-swu-scripts
2. Move wpa_supplicant configs to navq-wpa-supplicant
3. Move nxp_depmod.conf and nxp_modules.conf files to navq-kmod-mlan