### PR TITLE
NAVQP-113: Initialize CANs with correct configuration.

### DIFF
--- a/recipes-connectivity/network-interface-config/install-interface-config/10-can.network
+++ b/recipes-connectivity/network-interface-config/install-interface-config/10-can.network
@@ -2,7 +2,9 @@
 Name=can*
 
 [CAN]
-BitRate=500000
+BitRate=1000000
 DataBitRate=4000000
 FDMode=yes
-
+FDNonISO=no
+RestartSec="0.1s"
+Loopback=no


### PR DESCRIPTION
Allows for identical configuration of CANs instead of having to run:
`sudo ip link set can0 up type can bitrate 1000000 dbitrate 4000000 loopback off fd on fd-non-iso off restart-ms 100`