### PR TITLE
NAVQP-178: Remove warning when running "cmake".

### DIFF
--- a/scripts/build6-1-22.sh
+++ b/scripts/build6-1-22.sh
@@ -131,6 +131,11 @@ DISTRO=${DISTRO} MACHINE=imx8mpnavq EULA=yes BUILD_DIR=builddir source ./${SETUP
 sed -i 's/^DL_DIR.*$/DL_DIR\ \?=\ \"\/home\/cache\/CACHE\/6.1.22\/downloads\/\"/' conf/local.conf || exit $?
 echo "SSTATE_DIR = \"/home/cache/CACHE/6.1.22/sstate-cache\"" >> conf/local.conf || exit $?
 echo "BBMASK += \"$BBMASK\"" >> conf/local.conf || exit $?
+
+# Don't build gstreamer curl plugin, to remove dependency of libcurl,
+# to avoid installing duplicate libraries.
+echo "PACKAGECONFIG:remove:pn-gstreamer1.0-plugins-bad = \"curl\"" >> conf/local.conf || exit $?
+
 sed -i -e "s/BB_DEFAULT_UMASK =/BB_DEFAULT_UMASK ?=/" ../sources/poky/meta/conf/bitbake.conf
 sed -i -e "s/PACKAGE_CLASSES ?\?=.*$/PACKAGE_CLASSES ?= \"package_$PACKAGING\"/" conf/local.conf
 


### PR DESCRIPTION
Removed "gstreamer1.0-plugins-bad-curl" plugin form the build, which causes installation of /usr/lib/libcurl.so.4 (dup of /lib/aarch64*/libcurl.so.4), which causes warning when running "cmake" or "curl".

This is a copy of the fix from buildbot-configs/ repo.