### PR TITLE
NAVQP-213: Add v4l2-camera package for ROS2

### DIFF
--- a/recipes-fsl/images/ros2-packages.inc
+++ b/recipes-fsl/images/ros2-packages.inc
@@ -96,6 +96,7 @@ ros-humble-unique-identifier-msgs \
 ros-humble-ur-dashboard-msgs \
 ros-humble-ur-msgs \
 ros-humble-urg-node-msgs \
+ros-humble-v4l2-camera \
 ros-humble-velodyne-msgs \
 ros-humble-vision-msgs \
 ros-humble-visualization-msgs \


### PR DESCRIPTION
This PR adds v4l2-camera package for ROS2

Unit test:
- Connect a USB camera to the NAVQ+ using USB hub;
- Open two consoles on NAVQ+;
- On console 1, run:
```
ros2 run v4l2_camera v4l2_camera_node --ros-args -p video_device:=/dev/video3
```
- On console 2, run:
```
ros2 topic list
```
- Observe following topics appear in the list:
```
/camera_info
/image_raw
/image_raw/compressed
/image_raw/compressedDepth
/image_raw/theora

```